### PR TITLE
Fix `org.eclipse.help` plug-in feature dependency. Bump revision/patch number

### DIFF
--- a/com.wdev91.eclipse.copyright.feature/feature.xml
+++ b/com.wdev91.eclipse.copyright.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.wdev91.eclipse.copyright.feature"
       label="%featureName"
-      version="1.5.0"
+      version="1.5.1"
       provider-name="%providerName">
 
    <description>
@@ -52,19 +52,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       <import plugin="org.eclipse.core.resources" version="3.5.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.ui" version="3.5.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.ui.ide"/>
+      <import plugin="org.eclipse.help"/>
    </requires>
 
    <plugin
          id="com.wdev91.eclipse.copyright"
          download-size="88"
          install-size="88"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.help"
-         download-size="0"
-         install-size="0"
          version="0.0.0"
          unpack="false"/>
 

--- a/com.wdev91.eclipse.copyright.site/site.xml
+++ b/com.wdev91.eclipse.copyright.site/site.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/com.wdev91.eclipse.copyright.feature_1.5.0.jar" id="com.wdev91.eclipse.copyright.feature" version="1.5.0"/>
+   <feature url="features/com.wdev91.eclipse.copyright.feature_1.5.1.jar" id="com.wdev91.eclipse.copyright.feature" version="1.5.1"/>
 </site>

--- a/com.wdev91.eclipse.copyright/META-INF/MANIFEST.MF
+++ b/com.wdev91.eclipse.copyright/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: com.wdev91.eclipse.copyright;singleton:=true
-Bundle-Version: 1.5.0
+Bundle-Version: 1.5.1
 Bundle-Activator: com.wdev91.eclipse.copyright.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.5.0",

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>fr.jmini.jxlint</groupId>
     <artifactId>root</artifactId>
-    <version>1.5.0</version>
+    <version>1.5.1</version>
     <packaging>pom</packaging>
 
     <pluginRepositories>


### PR DESCRIPTION
Resolves issue #2.

* com.wdev91.eclipse.copyright.feature/feature.xml: Move `org.eclipse.help` from included plug-ins to required plug-ins and bump revision number
* com.wdev91.eclipse.copyright.site/site.xml: Bump revision number
* com.wdev91.eclipse.copyright/META-INF/MANIFEST.MF: Bump revision number
* pom.xml: Bump revision number