### PR TITLE
Added version constraint range on all dependencies. Fixes #10. Fixes #11

### DIFF
--- a/com.wdev91.eclipse.copyright/META-INF/MANIFEST.MF
+++ b/com.wdev91.eclipse.copyright/META-INF/MANIFEST.MF
@@ -5,10 +5,10 @@ Bundle-SymbolicName: com.wdev91.eclipse.copyright;singleton:=true
 Bundle-Version: 1.5.3
 Bundle-Activator: com.wdev91.eclipse.copyright.Activator
 Bundle-Vendor: %providerName
-Require-Bundle: org.eclipse.core.runtime;bundle-version="3.5.0",
- org.eclipse.core.resources;bundle-version="3.5.0",
- org.eclipse.ui;bundle-version="3.5.0",
- org.eclipse.ui.ide
+Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.5.0,4.0.0)",
+ org.eclipse.core.resources;bundle-version="[3.5.0,4.0.0)",
+ org.eclipse.ui;bundle-version="[3.5.0,4.0.0)",
+ org.eclipse.ui.ide;bundle-version="[3.5.0,4.0.0)"
 Eclipse-LazyStart: true
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin


### PR DESCRIPTION
Bugs #10 and #11 are I believe fixed by this simple code change, which allows a range of versions of the required Eclipse dependencies